### PR TITLE
Send confirmation email after registration

### DIFF
--- a/src/app/api/attendees/route.ts
+++ b/src/app/api/attendees/route.ts
@@ -1,4 +1,5 @@
 import { db } from "@/lib/prisma";
+import { sendEmail } from "@/lib/mail";
 import { NextRequest, NextResponse } from "next/server";
 
 interface Attendee {
@@ -61,6 +62,13 @@ export async function POST(request: NextRequest) {
     });
 
     console.log("New Registration Received and Stored:", newAttendee);
+
+    // Send confirmation email to attendee
+    await sendEmail(
+      email,
+      "Confirmación de registro",
+      `Hola ${name}, tu registro al evento ha sido recibido. ¡Gracias!`,
+    );
 
     return NextResponse.json(
       { message: "Registration successful!", data: newAttendee },


### PR DESCRIPTION
## Summary
- send confirmation email after a user submits the registration form

## Testing
- `bun run lint`
- `bun run build` *(fails: Failed to fetch font `Poppins`)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0896b8f88329ad101e15a6c35b4e