### PR TITLE
feat: show toast on form errors

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,10 @@ export default function Home() {
   const [currentStep, setCurrentStep] = useState(1);
   const [message, setMessage] = useState({ text: "", show: false });
 
+  const showMessage = (text: string) => {
+    setMessage({ text, show: true });
+  };
+
   // Handle message display and timeout
   useEffect(() => {
     if (message.show) {
@@ -22,7 +26,7 @@ export default function Home() {
   }, [message]);
 
   const handleNoClick = () => {
-    setMessage({ text: "Qué lástima. ¡Te extrañaremos! 😢", show: true });
+    showMessage("Qué lástima. ¡Te extrañaremos! 😢");
   };
 
   const renderStep = () => {
@@ -35,7 +39,12 @@ export default function Home() {
           />
         );
       case 2:
-        return <Step2_Form onSubmit={() => setCurrentStep(3)} />;
+        return (
+          <Step2_Form
+            onSubmit={() => setCurrentStep(3)}
+            showMessage={showMessage}
+          />
+        );
       case 3:
         return <Step3_ThankYou />;
       default:

--- a/src/components/Step2_Form.tsx
+++ b/src/components/Step2_Form.tsx
@@ -1,8 +1,13 @@
 "use client";
 import { FormEvent, useState } from "react";
 import { motion } from "framer-motion";
-
-export default function Step2_Form({ onSubmit }: { onSubmit: () => void }) {
+export default function Step2_Form({
+  onSubmit,
+  showMessage,
+}: {
+  onSubmit: () => void;
+  showMessage: (msg: string) => void;
+}) {
   const [hasAllergy, setHasAllergy] = useState<string | null>(null);
   const [selectedDiets, setSelectedDiets] = useState<string[]>([]);
   const [customDiet, setCustomDiet] = useState<string>("");
@@ -22,9 +27,26 @@ export default function Step2_Form({ onSubmit }: { onSubmit: () => void }) {
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    const { name, email, company, role } = formValues;
+    if (!name || !email || !company || !role) {
+      showMessage("Por favor completa todos los campos.");
+      return;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      showMessage("Por favor ingresa un email válido.");
+      return;
+    }
+
+    if (hasAllergy === null) {
+      showMessage("Por favor indica si tienes alguna alergia.");
+      return;
+    }
+
     const formData = new FormData(e.currentTarget);
 
-    // Concatenamos dietas seleccionadas
     const diets = [...selectedDiets];
     if (customDiet.trim()) diets.push(`otra: ${customDiet.trim()}`);
     formData.set("diet", diets.join("-"));
@@ -41,8 +63,12 @@ export default function Step2_Form({ onSubmit }: { onSubmit: () => void }) {
       if (response.ok) {
         console.log("Form submitted successfully!");
         onSubmit();
-      } else console.error("Form submission failed.", response);
+      } else {
+        showMessage("No pudimos enviar tus datos. Intenta nuevamente.");
+        console.error("Form submission failed.", response);
+      }
     } catch (error) {
+      showMessage("Ocurrió un error al enviar el formulario.");
       console.error("An error occurred:", error);
     }
   };
@@ -87,7 +113,11 @@ export default function Step2_Form({ onSubmit }: { onSubmit: () => void }) {
         variants={itemVariants}
         className="px-8 rounded-3xl bg-white/40 shadow-md backdrop-blur-lg border-2 border-white/30"
       >
-        <form onSubmit={handleSubmit} className="space-y-6 relative py-6 pb-4">
+        <form
+          onSubmit={handleSubmit}
+          noValidate
+          className="space-y-6 relative py-6 pb-4"
+        >
           {/* Campos principales */}
           <motion.div
             variants={itemVariants}
@@ -106,7 +136,6 @@ export default function Step2_Form({ onSubmit }: { onSubmit: () => void }) {
                   type={field === "email" ? "email" : "text"}
                   id={field}
                   name={field}
-                  required
                   value={formValues[field as keyof typeof formValues]}
                   onChange={(e) =>
                     setFormValues((prev) => ({


### PR DESCRIPTION
## Summary
- add global message handler to present toast notifications
- display validation and submission errors from Step2 form as toast messages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb14c80df88329b2af5fe23d930984