### PR TITLE
Add HTML confirmation email template

### DIFF
--- a/src/app/api/attendees/route.ts
+++ b/src/app/api/attendees/route.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/prisma";
 import { sendEmail } from "@/lib/mail";
+import { confirmationEmailTemplate } from "@/lib/templates/confirmationEmail";
 import { NextRequest, NextResponse } from "next/server";
 
 interface Attendee {
@@ -64,11 +65,9 @@ export async function POST(request: NextRequest) {
     console.log("New Registration Received and Stored:", newAttendee);
 
     // Send confirmation email to attendee
-    await sendEmail(
-      email,
-      "Confirmación de registro",
-      `Hola ${name}, tu registro al evento ha sido recibido. ¡Gracias!`,
-    );
+    const text = `Hola ${name}, tu registro al evento ha sido recibido. ¡Gracias!`;
+    const html = confirmationEmailTemplate(name);
+    await sendEmail(email, "Confirmación de registro", text, html);
 
     return NextResponse.json(
       { message: "Registration successful!", data: newAttendee },

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -2,13 +2,19 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-export async function sendEmail(to: string, subject: string, text: string) {
+export async function sendEmail(
+  to: string,
+  subject: string,
+  text: string,
+  html?: string,
+) {
   try {
     await resend.emails.send({
       from: "Finnegans | Invitacion Evento <noreply@finneg.com>",
       to,
       subject,
       text,
+      ...(html ? { html } : {}),
     });
   } catch (error) {
     console.error("Error sending email:", error);

--- a/src/lib/templates/confirmationEmail.ts
+++ b/src/lib/templates/confirmationEmail.ts
@@ -1,0 +1,46 @@
+export function confirmationEmailTemplate(name: string) {
+  return `<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Confirmación de registro</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        background-color: #f9f9f9;
+        margin: 0;
+        padding: 0;
+      }
+      .container {
+        max-width: 600px;
+        margin: 0 auto;
+        background-color: #ffffff;
+        padding: 24px;
+      }
+      .header {
+        text-align: center;
+        background-color: #222222;
+        color: #ffffff;
+        padding: 12px 0;
+        font-size: 20px;
+        font-weight: bold;
+      }
+      .footer {
+        text-align: center;
+        color: #888888;
+        font-size: 12px;
+        padding-top: 24px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">Confirmación de registro</div>
+      <p>Hola ${name}, tu registro al evento ha sido recibido. ¡Gracias por unirte!</p>
+      <p>Esperamos verte pronto.</p>
+      <div class="footer">&copy; ${new Date().getFullYear()} Finnegans. Todos los derechos reservados.</div>
+    </div>
+  </body>
+</html>`;
+}


### PR DESCRIPTION
## Summary
- add HTML confirmation email template with header and footer
- support HTML emails in mail helper
- send confirmation emails using template on attendee registration

## Testing
- `npm test` (fails: missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb1bb79d888329b69200c4f6208492