### PR TITLE
Add RESTful event management endpoints for dashboard

### DIFF
--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -1,0 +1,203 @@
+import { db } from "@/lib/prisma";
+import { EventStatus, Prisma } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
+
+const VALID_EVENT_STATUSES: EventStatus[] = [
+  "UPCOMING",
+  "COMPLETED",
+  "PLANNING",
+  "CANCELED",
+];
+
+const isValidStatus = (status: string): status is EventStatus =>
+  VALID_EVENT_STATUSES.includes(status as EventStatus);
+
+const parseEventId = (id: string) => {
+  const eventId = Number(id);
+  return Number.isInteger(eventId) && eventId > 0 ? eventId : null;
+};
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const eventId = parseEventId(params.id);
+
+  if (!eventId) {
+    return NextResponse.json(
+      { message: "A valid event id must be provided." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const event = await db.event.findUnique({
+      where: { id: eventId },
+      include: { attendees: true },
+    });
+
+    if (!event) {
+      return NextResponse.json(
+        { message: "The requested event could not be found." },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(event, { status: 200 });
+  } catch (error) {
+    console.error("GET Event by ID API Error:", error);
+    return NextResponse.json(
+      { message: "An internal server error occurred." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const eventId = parseEventId(params.id);
+
+  if (!eventId) {
+    return NextResponse.json(
+      { message: "A valid event id must be provided." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const data: Prisma.EventUpdateInput = {};
+
+    if ("name" in body) {
+      const name = typeof body.name === "string" ? body.name.trim() : "";
+      if (!name) {
+        return NextResponse.json(
+          { message: "Event name cannot be empty." },
+          { status: 400 },
+        );
+      }
+      data.name = name;
+    }
+
+    if ("location" in body) {
+      const location =
+        typeof body.location === "string" ? body.location.trim() : "";
+      if (!location) {
+        return NextResponse.json(
+          { message: "Event location cannot be empty." },
+          { status: 400 },
+        );
+      }
+      data.location = location;
+    }
+
+    if ("status" in body) {
+      const rawStatus =
+        typeof body.status === "string" ? body.status.toUpperCase() : "";
+      if (!isValidStatus(rawStatus)) {
+        return NextResponse.json(
+          { message: "Event status provided is not valid." },
+          { status: 400 },
+        );
+      }
+      data.status = rawStatus as EventStatus;
+    }
+
+    if ("capacity" in body) {
+      const capacityNumber = Number(body.capacity);
+      if (!Number.isFinite(capacityNumber) || capacityNumber < 0) {
+        return NextResponse.json(
+          { message: "Event capacity must be a non-negative number." },
+          { status: 400 },
+        );
+      }
+      data.capacity = capacityNumber;
+    }
+
+    if ("date" in body) {
+      const eventDate = new Date(body.date);
+      if (Number.isNaN(eventDate.getTime())) {
+        return NextResponse.json(
+          { message: "A valid event date must be provided." },
+          { status: 400 },
+        );
+      }
+      data.date = eventDate;
+    }
+
+    if (Object.keys(data).length === 0) {
+      return NextResponse.json(
+        { message: "No valid fields were provided for update." },
+        { status: 400 },
+      );
+    }
+
+    const updatedEvent = await db.event.update({
+      where: { id: eventId },
+      data,
+      include: { attendees: true },
+    });
+
+    return NextResponse.json(updatedEvent, { status: 200 });
+  } catch (error) {
+    console.error("PATCH Event API Error:", error);
+
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      return NextResponse.json(
+        { message: "The event you tried to update does not exist." },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      { message: "An internal server error occurred." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const eventId = parseEventId(params.id);
+
+  if (!eventId) {
+    return NextResponse.json(
+      { message: "A valid event id must be provided." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await db.attendee.deleteMany({ where: { eventId } });
+    await db.event.delete({ where: { id: eventId } });
+
+    return NextResponse.json(
+      { message: "Event deleted successfully." },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("DELETE Event API Error:", error);
+
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      return NextResponse.json(
+        { message: "The event you tried to delete does not exist." },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      { message: "An internal server error occurred." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,16 +1,25 @@
-// File: app/api/events/route.ts
 import { db } from "@/lib/prisma";
+import { EventStatus } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
+
+const VALID_EVENT_STATUSES: EventStatus[] = [
+  "UPCOMING",
+  "COMPLETED",
+  "PLANNING",
+  "CANCELED",
+];
+
+const isValidStatus = (status: string): status is EventStatus =>
+  VALID_EVENT_STATUSES.includes(status as EventStatus);
 
 export async function GET() {
   try {
     const events = await db.event.findMany({
-      // Include the attendees related to each event
       include: {
         attendees: true,
       },
       orderBy: {
-        date: "desc", // Show the newest events first
+        date: "desc",
       },
     });
 
@@ -24,26 +33,61 @@ export async function GET() {
   }
 }
 
-export async function PATCH(request: NextRequest) {
+export async function POST(request: NextRequest) {
   try {
-    const params = request.nextUrl.searchParams;
-    const id = params.get("id");
-    const { name, location, status, date, capacity } = await request.json();
+    const body = await request.json();
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    const location =
+      typeof body.location === "string" ? body.location.trim() : "";
+    const rawStatus =
+      typeof body.status === "string" ? body.status.toUpperCase() : "";
+    const capacityNumber = Number(body.capacity);
+    const eventDate = new Date(body.date);
 
-    const updatedEvent = await db.event.update({
-      where: { id: Number(id) as number },
+    if (!name || !location) {
+      return NextResponse.json(
+        { message: "Missing required fields for event creation." },
+        { status: 400 },
+      );
+    }
+
+    if (!body.date || Number.isNaN(eventDate.getTime())) {
+      return NextResponse.json(
+        { message: "A valid event date must be provided." },
+        { status: 400 },
+      );
+    }
+
+    if (!Number.isFinite(capacityNumber) || capacityNumber < 0) {
+      return NextResponse.json(
+        { message: "Event capacity must be a non-negative number." },
+        { status: 400 },
+      );
+    }
+
+    if (!isValidStatus(rawStatus)) {
+      return NextResponse.json(
+        { message: "Event status provided is not valid." },
+        { status: 400 },
+      );
+    }
+
+    const newEvent = await db.event.create({
       data: {
         name,
         location,
-        status,
-        date: new Date(date),
-        capacity,
+        status: rawStatus as EventStatus,
+        capacity: capacityNumber,
+        date: eventDate,
+      },
+      include: {
+        attendees: true,
       },
     });
 
-    return NextResponse.json(updatedEvent, { status: 200 });
+    return NextResponse.json(newEvent, { status: 201 });
   } catch (error) {
-    console.error("PATCH Event API Error:", error);
+    console.error("POST Event API Error:", error);
     return NextResponse.json(
       { message: "An internal server error occurred." },
       { status: 500 },

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -53,6 +53,7 @@ export default function App() {
         throw new Error("Falló la carga de datos");
       const eventsData = await eventsRes.json();
       const attendeesData = await attendeesRes.json();
+      setError(null);
       setEvents(eventsData);
       setAttendees(attendeesData);
     } catch (err) {
@@ -83,7 +84,7 @@ export default function App() {
   ) => {
     const method = eventToEdit ? "PATCH" : "POST";
     const url = eventToEdit
-      ? `/api/events?id=${eventToEdit.id}`
+      ? `/api/events/${eventToEdit.id}`
       : "/api/events";
     try {
       const response = await fetch(url, {


### PR DESCRIPTION
## Summary
- add validation-backed POST handler for `/api/events`
- expose `/api/events/[id]` for fetching, updating, and deleting events
- refresh the dashboard client to use the new routes and clear stale errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fa7a7f9fc48329bc4a8c0b97d6c6d6