### PR TITLE
Enable attendee deletion from dashboard

### DIFF
--- a/src/app/api/attendees/[id]/route.ts
+++ b/src/app/api/attendees/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { db } from "@/lib/prisma";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const attendeeId = Number(params.id);
+
+  if (!params.id || Number.isNaN(attendeeId)) {
+    return NextResponse.json(
+      { message: "Invalid attendee id." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await db.attendee.delete({
+      where: { id: attendeeId },
+    });
+
+    return NextResponse.json(
+      { message: "Attendee deleted successfully." },
+      { status: 200 },
+    );
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      return NextResponse.json(
+        { message: "Attendee not found." },
+        { status: 404 },
+      );
+    }
+
+    console.error("DELETE Attendee API Error:", error);
+
+    return NextResponse.json(
+      { message: "An internal server error occurred." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -44,6 +44,7 @@ export default function App() {
 
   const fetchData = async () => {
     setIsLoading(true);
+    setError(null);
     try {
       const [eventsRes, attendeesRes] = await Promise.all([
         fetch("/api/events"),
@@ -114,6 +115,29 @@ export default function App() {
     }
   };
 
+  const handleDeleteAttendee = async (attendeeId: number) => {
+    if (
+      window.confirm(
+        "¿Estás seguro de que quieres eliminar a este asistente?",
+      )
+    ) {
+      try {
+        const response = await fetch(`/api/attendees/${attendeeId}`, {
+          method: "DELETE",
+        });
+        if (!response.ok)
+          throw new Error("No se pudo eliminar al asistente");
+        await fetchData();
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Error al eliminar al asistente",
+        );
+      }
+    }
+  };
+
   const handleViewEventDetails = (eventId: number) => {
     setViewingEventId(eventId);
   };
@@ -165,6 +189,7 @@ export default function App() {
             events={events}
             attendees={attendees}
             isLoading={isLoading}
+            onDelete={handleDeleteAttendee}
           />
         );
       default:

--- a/src/components/dashboard/AttendeesPage.tsx
+++ b/src/components/dashboard/AttendeesPage.tsx
@@ -2,15 +2,22 @@
 import React, { useState, useMemo } from "react";
 import Image from "next/image";
 import { Card } from "./ui/Card";
+import { Button } from "./ui/Button";
 import { Event, Attendee } from "@/lib/types";
 
 interface AttendeesPageProps {
   events: Event[];
   attendees: Attendee[];
   isLoading: boolean;
+  onDelete: (attendeeId: number) => void;
 }
 
-export const AttendeesPage = ({ events, attendees, isLoading }: AttendeesPageProps) => {
+export const AttendeesPage = ({
+  events,
+  attendees,
+  isLoading,
+  onDelete,
+}: AttendeesPageProps) => {
   const [selectedEventId, setSelectedEventId] = useState<string>("all");
   const [searchTerm, setSearchTerm] = useState("");
   const [dietaryFilter, setDietaryFilter] = useState("all");
@@ -86,6 +93,9 @@ export const AttendeesPage = ({ events, attendees, isLoading }: AttendeesPagePro
                 <th scope="col" className="px-6 py-3">
                   Dieta Especial
                 </th>
+                <th scope="col" className="px-6 py-3 text-right">
+                  Acciones
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -103,6 +113,9 @@ export const AttendeesPage = ({ events, attendees, isLoading }: AttendeesPagePro
                     </td>
                     <td className="px-6 py-4">
                       <div className="h-4 bg-white/10 rounded w-1/4 animate-pulse"></div>
+                    </td>
+                    <td className="px-6 py-4 text-right">
+                      <div className="h-8 w-20 bg-white/10 rounded-lg animate-pulse"></div>
                     </td>
                   </tr>
                 ))}
@@ -146,8 +159,27 @@ export const AttendeesPage = ({ events, attendees, isLoading }: AttendeesPagePro
                         <span className="text-white/50">-</span>
                       )}
                     </td>
+                    <td className="px-6 py-4 text-right">
+                      <Button
+                        variant="danger"
+                        onClick={() => onDelete(attendee.id)}
+                        className="px-3 py-1 text-xs"
+                      >
+                        Eliminar
+                      </Button>
+                    </td>
                   </tr>
                 ))}
+              {!isLoading && filteredAttendees.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-6 py-8 text-center text-white/60"
+                  >
+                    No se encontraron asistentes para los filtros actuales.
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary
- add an API route to delete attendee records
- wire the dashboard to call the deletion endpoint and refresh data
- expose a delete action in the attendees table along with an empty-state message

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fa7c72397c8329808a87ea5b9a3f72