### PR TITLE
Handle Next.js route params as promises in API handlers

### DIFF
--- a/src/app/api/attendees/[id]/route.ts
+++ b/src/app/api/attendees/[id]/route.ts
@@ -2,13 +2,34 @@ import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { db } from "@/lib/prisma";
 
+type RouteContext = {
+  params?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+const resolveAttendeeId = async (
+  params?: Promise<Record<string, string | string[] | undefined>>,
+) => {
+  if (!params) {
+    return null;
+  }
+
+  const { id } = await params;
+
+  if (typeof id !== "string") {
+    return null;
+  }
+
+  const attendeeId = Number(id);
+  return Number.isInteger(attendeeId) ? attendeeId : null;
+};
+
 export async function DELETE(
   _request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteContext,
 ) {
-  const attendeeId = Number(params.id);
+  const attendeeId = await resolveAttendeeId(params);
 
-  if (!params.id || Number.isNaN(attendeeId)) {
+  if (attendeeId === null) {
     return NextResponse.json(
       { message: "Invalid attendee id." },
       { status: 400 },

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -17,11 +17,31 @@ const parseEventId = (id: string) => {
   return Number.isInteger(eventId) && eventId > 0 ? eventId : null;
 };
 
+type RouteContext = {
+  params?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+const resolveEventId = async (
+  params?: Promise<Record<string, string | string[] | undefined>>,
+) => {
+  if (!params) {
+    return null;
+  }
+
+  const { id } = await params;
+
+  if (typeof id !== "string") {
+    return null;
+  }
+
+  return parseEventId(id);
+};
+
 export async function GET(
   _request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: RouteContext,
 ) {
-  const eventId = parseEventId(params.id);
+  const eventId = await resolveEventId(params);
 
   if (!eventId) {
     return NextResponse.json(
@@ -55,9 +75,9 @@ export async function GET(
 
 export async function PATCH(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: RouteContext,
 ) {
-  const eventId = parseEventId(params.id);
+  const eventId = await resolveEventId(params);
 
   if (!eventId) {
     return NextResponse.json(
@@ -163,9 +183,9 @@ export async function PATCH(
 
 export async function DELETE(
   _request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: RouteContext,
 ) {
-  const eventId = parseEventId(params.id);
+  const eventId = await resolveEventId(params);
 
   if (!eventId) {
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- await the promised `params` object in the attendee delete route and validate the id before deleting
- resolve the promised `params` object in the event detail routes so the id is validated before database work

## Testing
- bun run build *(fails: Google Fonts stylesheet could not be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa7e825f248329aa5a26fcc01f8779