### PR TITLE
Fix DELETE attendee route context type

### DIFF
--- a/src/app/api/attendees/[id]/route.ts
+++ b/src/app/api/attendees/[id]/route.ts
@@ -3,17 +3,17 @@ import { Prisma } from "@prisma/client";
 import { db } from "@/lib/prisma";
 
 type RouteContext = {
-  params?: Promise<Record<string, string | string[] | undefined>>;
+  params: {
+    id: string;
+  };
 };
 
-const resolveAttendeeId = async (
-  params?: Promise<Record<string, string | string[] | undefined>>,
-) => {
+const resolveAttendeeId = (params: RouteContext["params"]) => {
   if (!params) {
     return null;
   }
 
-  const { id } = await params;
+  const { id } = params;
 
   if (typeof id !== "string") {
     return null;
@@ -27,7 +27,7 @@ export async function DELETE(
   _request: NextRequest,
   { params }: RouteContext,
 ) {
-  const attendeeId = await resolveAttendeeId(params);
+  const attendeeId = resolveAttendeeId(params);
 
   if (attendeeId === null) {
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- adjust the attendee DELETE route context to use the correct params shape
- simplify attendee id resolution to use the synchronous params object

## Testing
- bun run build *(fails: GET https://registry.npmjs.org/prisma - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68facc3bfb6c8329a1d687d08ab348a7