### PR TITLE
Fix attendee DELETE route context typing

### DIFF
--- a/src/app/api/attendees/[id]/route.ts
+++ b/src/app/api/attendees/[id]/route.ts
@@ -3,17 +3,17 @@ import { Prisma } from "@prisma/client";
 import { db } from "@/lib/prisma";
 
 type RouteContext = {
-  params?: Promise<Record<string, string | string[] | undefined>>;
+  params?: {
+    id?: string | string[];
+  };
 };
 
-const resolveAttendeeId = async (
-  params?: Promise<Record<string, string | string[] | undefined>>,
-) => {
+const resolveAttendeeId = (params?: RouteContext["params"]) => {
   if (!params) {
     return null;
   }
 
-  const { id } = await params;
+  const { id } = params;
 
   if (typeof id !== "string") {
     return null;
@@ -27,7 +27,7 @@ export async function DELETE(
   _request: NextRequest,
   { params }: RouteContext,
 ) {
-  const attendeeId = await resolveAttendeeId(params);
+  const attendeeId = resolveAttendeeId(params);
 
   if (attendeeId === null) {
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- adjust the attendee DELETE route handler to accept a synchronous params object as required by the App Router
- simplify attendee id parsing now that the params object is no longer asynchronous

## Testing
- bun run build *(fails: cannot fetch Google Fonts in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68facd8895248329b9a1d8e3ec545ae5