### PR TITLE
Fix attendee delete route context typing

### DIFF
--- a/src/app/api/attendees/[id]/route.ts
+++ b/src/app/api/attendees/[id]/route.ts
@@ -3,33 +3,18 @@ import { Prisma } from "@prisma/client";
 import { db } from "@/lib/prisma";
 
 type RouteContext = {
-  params?: Promise<Record<string, string | string[] | undefined>>;
-};
-
-const resolveAttendeeId = async (
-  params?: Promise<Record<string, string | string[] | undefined>>,
-) => {
-  if (!params) {
-    return null;
-  }
-
-  const { id } = await params;
-
-  if (typeof id !== "string") {
-    return null;
-  }
-
-  const attendeeId = Number(id);
-  return Number.isInteger(attendeeId) ? attendeeId : null;
+  params: {
+    id: string;
+  };
 };
 
 export async function DELETE(
   _request: NextRequest,
   { params }: RouteContext,
 ) {
-  const attendeeId = await resolveAttendeeId(params);
+  const attendeeId = Number(params.id);
 
-  if (attendeeId === null) {
+  if (!Number.isInteger(attendeeId)) {
     return NextResponse.json(
       { message: "Invalid attendee id." },
       { status: 400 },


### PR DESCRIPTION
## Summary
- simplify the attendee DELETE API handler to use the standard Next.js route context signature
- keep server-side validation for the attendee id before performing the deletion

## Testing
- bun run build *(fails: unable to fetch Google Fonts due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68fad74a20a883299febfe347ba8997b