### PR TITLE
Fix attendee DELETE route context typing

### DIFF
--- a/src/app/api/attendees/[id]/route.ts
+++ b/src/app/api/attendees/[id]/route.ts
@@ -2,32 +2,20 @@ import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { db } from "@/lib/prisma";
 
-type RouteContext = {
-  params?: Promise<Record<string, string | string[] | undefined>>;
-};
-
-const resolveAttendeeId = async (
-  params?: Promise<Record<string, string | string[] | undefined>>,
-) => {
-  if (!params) {
+const resolveAttendeeId = (params?: { id?: string }) => {
+  if (!params || typeof params.id !== "string") {
     return null;
   }
 
-  const { id } = await params;
-
-  if (typeof id !== "string") {
-    return null;
-  }
-
-  const attendeeId = Number(id);
+  const attendeeId = Number(params.id);
   return Number.isInteger(attendeeId) ? attendeeId : null;
 };
 
 export async function DELETE(
   _request: NextRequest,
-  { params }: RouteContext,
+  { params }: { params: { id?: string } },
 ) {
-  const attendeeId = await resolveAttendeeId(params);
+  const attendeeId = resolveAttendeeId(params);
 
   if (attendeeId === null) {
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- remove the custom RouteContext type that expected promise-based params
- update the DELETE handler to resolve the attendee id from the standard Next.js params shape

## Testing
- bun run build *(fails: unable to fetch the Poppins font from Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fae1dce3e88329b14185ac5c05ce7a