### PR TITLE
Fix attendee DELETE handler params typing

### DIFF
--- a/src/app/api/attendees/[id]/route.ts
+++ b/src/app/api/attendees/[id]/route.ts
@@ -2,20 +2,28 @@ import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { db } from "@/lib/prisma";
 
-const resolveAttendeeId = (params?: { id?: string }) => {
-  if (!params || typeof params.id !== "string") {
+const resolveAttendeeId = async (
+  params?: Promise<Record<string, string | string[] | undefined>>,
+) => {
+  if (!params) {
     return null;
   }
 
-  const attendeeId = Number(params.id);
+  const { id } = await params;
+
+  if (typeof id !== "string") {
+    return null;
+  }
+
+  const attendeeId = Number(id);
   return Number.isInteger(attendeeId) ? attendeeId : null;
 };
 
 export async function DELETE(
   _request: NextRequest,
-  { params }: { params: { id?: string } },
+  { params }: RouteContext<"/api/attendees/[id]">,
 ) {
-  const attendeeId = resolveAttendeeId(params);
+  const attendeeId = await resolveAttendeeId(params);
 
   if (attendeeId === null) {
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- update the attendee DELETE route handler to use the RouteContext helper
- resolve the dynamic attendee id from the async params object returned by RouteContext

## Testing
- bun run build *(fails: Unable to download external Poppins font due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68fae319110483299767f3dc5c31fbcc