### PR TITLE
Fix event route context typing

### DIFF
--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -17,10 +17,6 @@ const parseEventId = (id: string) => {
   return Number.isInteger(eventId) && eventId > 0 ? eventId : null;
 };
 
-type RouteContext = {
-  params?: Promise<Record<string, string | string[] | undefined>>;
-};
-
 const resolveEventId = async (
   params?: Promise<Record<string, string | string[] | undefined>>,
 ) => {
@@ -39,7 +35,7 @@ const resolveEventId = async (
 
 export async function GET(
   _request: NextRequest,
-  { params }: RouteContext,
+  { params }: RouteContext<"/api/events/[id]">,
 ) {
   const eventId = await resolveEventId(params);
 
@@ -75,7 +71,7 @@ export async function GET(
 
 export async function PATCH(
   request: NextRequest,
-  { params }: RouteContext,
+  { params }: RouteContext<"/api/events/[id]">,
 ) {
   const eventId = await resolveEventId(params);
 
@@ -183,7 +179,7 @@ export async function PATCH(
 
 export async function DELETE(
   _request: NextRequest,
-  { params }: RouteContext,
+  { params }: RouteContext<"/api/events/[id]">,
 ) {
   const eventId = await resolveEventId(params);
 


### PR DESCRIPTION
## Summary
- align the event route handler context typing with the Next.js-provided RouteContext
- remove the custom RouteContext type alias to avoid invalid GET handler signature

## Testing
- bun run build *(fails: Next.js build cannot download the Poppins font in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fae5e5a7b48329a9ddd979bb1cfc52